### PR TITLE
feat: Add circleCI config file to test circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+workflows:
+  build-test:
+    jobs:
+      -build
+
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.12.6
+    steps:
+      - checkout
+      - run: python --version


### PR DESCRIPTION
The config file spins up a python 3.12.6 image and prints python version